### PR TITLE
Compatibility with Flywheel block entity instancing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ repositories {
         name "LatvianModder"
         url "https://maven.latmod.com"
     }
+    maven { // Flywheel
+        name 'tterrag maven'
+        url 'https://maven.tterrag.com/'
+    }
 }
 
 version = "${project.mod_version}+${getVersionMetadata()}"
@@ -62,6 +66,9 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
+
+            // Disable refmap to launch game with Flywheel
+            property 'mixin.env.disableRefMap', 'true'
 
             mods {
                 examplemod {
@@ -136,6 +143,13 @@ dependencies {
     /*compileOnly fg.deobf(project.dependencies.create("dev.ftb.mods:ftb-chunks:${ftb_chunks_version}") {
         transitive = false
     })*/
+
+    def flywheel = fg.deobf("com.jozufozu.flywheel:Flywheel:${flywheel_version}")
+    if (project.use_third_party_mods) {
+        implementation flywheel
+    } else {
+        compileOnly flywheel
+    }
 
     annotationProcessor 'org.spongepowered:mixin:0.8.2:processor'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ archives_base_name=sodiumolithiumophosphor-forge
 # If true, third-party mods will be loaded during runtime in the developer run configurations
 use_third_party_mods = true
 databreaker_version = 0.2.4
+flywheel_version = 1.16-0.2.3.48
 
 # FTB-Chunks
 ftb_chunks_version=1605.2.3-build.75

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -21,9 +21,11 @@ public class SodiumClientMod {
     private static Logger LOGGER;
     private static String MOD_VERSION;
     public static boolean ftbChunksLoaded;
+    public static boolean flywheelLoaded;
 
     public SodiumClientMod() {
         ftbChunksLoaded = ModList.get().isLoaded("ftbchunks");
+        flywheelLoaded = ModList.get().isLoaded("flywheel");
         // Register the setup method for modloading
         //FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/FlywheelCompat.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/FlywheelCompat.java
@@ -1,0 +1,23 @@
+package me.jellysquid.mods.sodium.client.render;
+
+import java.util.Collection;
+
+import com.jozufozu.flywheel.backend.instancing.InstancedRenderRegistry;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import net.minecraft.tileentity.TileEntity;
+
+public class FlywheelCompat {
+
+    /**
+     * Filters a collection of TileEntities to avoid rendering conflicts with Flywheel.
+     *
+     * @param blockEntities The collection to be filtered.
+     */
+    public static void filterBlockEntityList(Collection<TileEntity> blockEntities) {
+        if (SodiumClientMod.flywheelLoaded) {
+            InstancedRenderRegistry r = InstancedRenderRegistry.getInstance();
+            blockEntities.removeIf(r::shouldSkipRender);
+        }
+    }
+
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -376,6 +376,8 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     public void onChunkRenderUpdated(int x, int y, int z, ChunkRenderData meshBefore, ChunkRenderData meshAfter) {
         ListUtil.updateList(this.globalBlockEntities, meshBefore.getGlobalBlockEntities(), meshAfter.getGlobalBlockEntities());
 
+        FlywheelCompat.filterBlockEntityList(this.globalBlockEntities);
+
         this.chunkRenderManager.onChunkRenderUpdates(x, y, z, meshAfter);
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -14,6 +14,7 @@ import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.compat.LegacyFogHelper;
 import me.jellysquid.mods.sodium.client.gl.device.CommandList;
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
+import me.jellysquid.mods.sodium.client.render.FlywheelCompat;
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildResult;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuilder;
@@ -282,6 +283,7 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
 
         if (!blockEntities.isEmpty()) {
             this.visibleBlockEntities.addAll(blockEntities);
+            FlywheelCompat.filterBlockEntityList(this.visibleBlockEntities);
         }
     }
 


### PR DESCRIPTION
https://github.com/Jozufozu/Flywheel/commit/a6377b5fe82ae1a9ac145379b7ba12100a9b1256 partially fixed #142, #166, #171, and https://github.com/Jozufozu/Flywheel/issues/30

This PR is the other half of the fix, allowing Flywheel's tile entity instancing to work seamlessly with sodium's optimizations.